### PR TITLE
Remove wordpress key introduced by PR #23

### DIFF
--- a/.artifakt/entrypoint.sh
+++ b/.artifakt/entrypoint.sh
@@ -4,23 +4,8 @@ set -e
 
 echo ">>>>>>>>>>>>>> START CUSTOM ENTRYPOINT SCRIPT <<<<<<<<<<<<<<<<< "
 
-# Generate file holding custom keys 
-if [[ ! -f /data/secret-key ]]; then
-  key=$(openssl rand -base64 24)
-  echo export WORDPRESS_SECRET=$key >> /data/secret-key
-fi
-
-source /data/secret-key
-
 mkdir -p /data/var/log /data/var/uploads /data/var/cache && \
-  ln -sfn /data/var /var/www/html/var  && \
-  chown www-data:www-data /data/var/log /data/var/uploads /data/var/cache
-
-# Generate file holding custom keys 
-if [[ ! -f /data/secret-key.php ]]; then
-  key=$(openssl rand -base64 24)
-  echo WORDPRESS_SECRET=$key >> /data/secret-key
-fi
-
+  ln -s /data/var /var/www/html/var && \
+  chown www-data:www-data /data/var/log /data/var/uploads /data/var/cache 
 
 echo ">>>>>>>>>>>>>> END CUSTOM ENTRYPOINT SCRIPT <<<<<<<<<<<<<<<<< "


### PR DESCRIPTION
I think the wordpress key was introduced by "mistake" on https://github.com/artifakt-io/base-symfony/pull/23 as it's not linked/used to the symfony 4.4 branch.
It's not on latest one also